### PR TITLE
Add packaging support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/elasticsearch_upgrade.py
+++ b/elasticsearch_upgrade.py
@@ -589,7 +589,7 @@ class ElasticsearchUpgrader:
         return True
 
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser(description='Performs a rolling upgrade of an Elasticsearch cluster')
     parser.add_argument('-n', '--nodes', help='Comma separated list of host names or IP addresses of nodes',
                         required=True)
@@ -654,3 +654,7 @@ if __name__ == '__main__':
 
     if not elasticsearch_upgrader.upgrade():
         exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup
+
+
+def readme():
+    with open('README.md') as f:
+        return f.read()
+
+
+setup(
+    name='elasticsearch_upgrade',
+    version='0.2.1',
+    description='Performs a rolling upgrade of an Elasticsearch cluster.',
+    long_description=readme(),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords='elasticsearch rolling upgrade',
+    url='https://github.com/pietervogelaar/elasticsearch_upgrade',
+    author='Pieter Vogelaar',
+    author_email='pieter@pietervogelaar.nl',
+    license='MIT',
+    install_requires=[
+        'requests',
+    ],
+    entry_points={
+        'console_scripts': ['elasticsearch-upgrade=elasticsearch_upgrade:main'],
+    },
+    include_package_data=True,
+    zip_safe=False)


### PR DESCRIPTION
Hi,
This PR aims to add packaging support to the `elasticsearch_upgrade.py` script so it can be installed via `pip`. Once installed, the `elasticsearch-upgrade` binary is available into the environment. It also fix some flake8-related issue.
Cheers