### PR TITLE
Package as a script and make it universally installable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(
     install_requires=[
         'requests',
     ],
-    entry_points={
-        'console_scripts': ['elasticsearch-upgrade=elasticsearch_upgrade:main'],
-    },
+    scripts=['elasticsearch_upgrade.py'],
     include_package_data=True,
     zip_safe=False)


### PR DESCRIPTION
As discussed in the PR#2 we stick with one file while making it installable via `pip`.